### PR TITLE
Fix: pagination and dropdown style

### DIFF
--- a/src/CourseTeamManagement/CoursesTable.jsx
+++ b/src/CourseTeamManagement/CoursesTable.jsx
@@ -145,7 +145,7 @@ export default function CoursesTable({
     }
 
     return data;
-  }, [search, status, org, userCoursesData, rowRoles, sortBy]);
+  }, [search, status, org, sortBy]);
 
   // Focus the search input when the component mounts
   useEffect(() => {

--- a/src/CourseTeamManagement/index.scss
+++ b/src/CourseTeamManagement/index.scss
@@ -45,6 +45,12 @@
 }
 
 .course-team-management-courses-table {
+    .pgn__data-table-row {
+        td {
+            overflow: visible;
+        }
+    }
+
     .pgn__data-table-actions-left {
         display: none;
     }


### PR DESCRIPTION
In this commit:
- dropdown was not showing due to recent changes in previous PRs
- on checkbox selection, table was navigating to 1st page

**Before:**
<video src="https://github.com/user-attachments/assets/cad28085-ab81-43c5-a6dd-7194427c72d2" controls></video>

**After:**
<video src="https://github.com/user-attachments/assets/614d493f-1fb0-4407-a4cb-8d88aa97e742" controls></video>



