### PR TITLE
fix: enterprise customer autocomplete for paragon update

### DIFF
--- a/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormCustomerDropdown.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormCustomerDropdown.jsx
@@ -11,39 +11,40 @@ import { selectProvisioningContext } from '../data/utils';
 import useProvisioningContext from '../data/hooks';
 import ProvisioningFormHelpText from './ProvisioningFormHelpText';
 
+const { ENTERPRISE_UUID } = PROVISIONING_PAGE_TEXT.FORM.CUSTOMER;
+
+const generateDropdownValue = (customer) => {
+  if (customer === ENTERPRISE_UUID.DROPDOWN_DEFAULT) {
+    return { option: ENTERPRISE_UUID.DROPDOWN_DEFAULT };
+  }
+  return {
+    uuid: customer.id,
+    option: `${customer.name} --- ${customer.id}`,
+  };
+};
+
+const generateAutosuggestOption = (dropDownValue) => (
+  <Form.AutosuggestOption id={dropDownValue.uuid || uuidv4()}>
+    {dropDownValue.option}
+  </Form.AutosuggestOption>
+);
+
 const ProvisioningFormCustomerDropdown = () => {
-  const { ENTERPRISE_UUID } = PROVISIONING_PAGE_TEXT.FORM.CUSTOMER;
   const [formData, customers, showInvalidField] = selectProvisioningContext('formData', 'customers', 'showInvalidField');
   const { subsidy } = showInvalidField;
   const isEnterpriseUuidDefinedAndFalse = subsidy?.enterpriseUUID === false;
   const { setCustomerUUID, getCustomers, setInvalidSubsidyFields } = useProvisioningContext();
   const [selected, setSelected] = useState({ title: '' });
-  const [dropdownValues, setDropdownValues] = useState([ENTERPRISE_UUID.DROPDOWN_DEFAULT]);
+  const [dropdownValues, setDropdownValues] = useState([generateDropdownValue(ENTERPRISE_UUID.DROPDOWN_DEFAULT)]);
   const debouncedSearch = useMemo(() => debounce(getCustomers, 500, {
     leading: false,
   }), [getCustomers]);
   const handleOnSelected = (value) => {
-    /* .includes('---') and .split(' --- ') are used to get the UUID from the
-    dropdown value, and populate the customerUUID state */
-    if (value && value.includes('---')) {
-      const valueUuid = value.split(' --- ')[1].trim();
-      setCustomerUUID(valueUuid);
+    if (value && value.selectionId) {
+      setCustomerUUID(value.selectionId);
       setInvalidSubsidyFields({ ...subsidy, enterpriseUUID: true });
     }
-    setSelected(prevState => ({ selected: { ...prevState.selected, title: value } }));
-  };
-  const updateDropdownList = () => {
-    if (customers.length > 0) {
-      const options = customers.map(customer => `${customer.name} --- ${customer.id}`);
-      setDropdownValues(options);
-    }
-  };
-  const updateDropdown = (value) => {
-    setCustomerUUID(value);
-    if (value?.length === 0 || customers.length === 0) {
-      return setDropdownValues(['No matching enterprise']);
-    }
-    return updateDropdownList();
+    setSelected(value);
   };
   useEffect(() => {
     const delayDebounceFn = setTimeout(() => {
@@ -51,23 +52,24 @@ const ProvisioningFormCustomerDropdown = () => {
     }, 500);
     return () => clearTimeout(delayDebounceFn);
   }, [formData.enterpriseUUID, debouncedSearch]);
+  useEffect(() => {
+    if (customers.length > 0) {
+      const options = customers.map(generateDropdownValue);
+      setDropdownValues(options);
+    }
+  }, [customers]);
   return (
     <Form.Group>
       <Form.Autosuggest
         floatingLabel={ENTERPRISE_UUID.TITLE}
-        value={selected.title}
-        onSelected={handleOnSelected}
-        onChange={updateDropdown}
+        value={selected}
+        onChange={handleOnSelected}
         helpMessage={ENTERPRISE_UUID.SUB_TITLE}
         errorMessageText={ENTERPRISE_UUID.ERROR.selected}
         data-testid="customer-uuid"
         isInvalid={isEnterpriseUuidDefinedAndFalse}
       >
-        {dropdownValues.map(option => (
-          <Form.AutosuggestOption key={uuidv4()}>
-            {option}
-          </Form.AutosuggestOption>
-        ))}
+        {dropdownValues.map(generateAutosuggestOption)}
       </Form.Autosuggest>
       <ProvisioningFormHelpText className="my-n3" />
       {isEnterpriseUuidDefinedAndFalse && (


### PR DESCRIPTION
This updates `ProvisioningFormCustomerDropdown` component to be compatible with Paragon `Form.Autosuggest` component updates (https://github.com/openedx/paragon/pull/2995).

## Testing Instructions (Devstack)
- Check out this branch
- Navigate to http://localhost:18450/enterprise-configuration/learner-credit/new
- Verify that existing customers appear in the Enterprise Customer dropdown
- Select customer, and continue filling out form
- Click 'Create learner credit plan' button
- Verify Learner Credit Plan created for customer