### PR TITLE
chore: migrate from @edx/frontend-enterprise-utils to @2uinc/frontend-enterprise-utils

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 const { createConfig } = require('@openedx/frontend-build');
 
-module.exports = createConfig('jest', {
+const config = createConfig('jest', {
   setupFiles: ['<rootDir>/src/setupTest.js'],
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.{js,jsx}'],
@@ -12,3 +12,10 @@ module.exports = createConfig('jest', {
     'src/supportHeader/ToggleVersion.jsx',
   ],
 });
+
+// @openedx/frontend-build's default transformIgnorePatterns only covers
+// @edx and @openedx scoped packages. Add @2uinc so Jest will transpile
+// those modules too.
+config.transformIgnorePatterns = ['node_modules/(?!@(open)?edx|@2uinc)'];
+
+module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@2uinc/frontend-enterprise-utils": "^10.0.2",
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-        "@edx/frontend-enterprise-utils": "9.1.0",
         "@edx/frontend-platform": "^8.3.2",
         "@edx/openedx-atlas": "^0.6.0",
         "@fortawesome/fontawesome-svg-core": "1.2.32",
@@ -56,6 +56,22 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "react-test-renderer": "^17.0.2"
+      }
+    },
+    "node_modules/@2uinc/frontend-enterprise-utils": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@2uinc/frontend-enterprise-utils/-/frontend-enterprise-utils-10.0.2.tgz",
+      "integrity": "sha512-J2aT8zdDaar4SxpYX/s+zWq79pYL72Wjp/JZvizrp9lrbozRZHV1QK3qK6fytaIw3ZYI4PmuFm3cciLnl7pNpA==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "history": "^4.10.1"
+      },
+      "peerDependencies": {
+        "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
+        "@testing-library/react": ">11.0.0 <17.0.0",
+        "react": "^16.12.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.12.0 || ^17.0.0 || ^18.0.0",
+        "react-router-dom": "^6.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -156,6 +172,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
       "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -2055,6 +2072,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -2077,6 +2095,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -2140,25 +2159,12 @@
         "eslint-plugin-react-hooks": "^1.7.0 || ^4.0.0"
       }
     },
-    "node_modules/@edx/frontend-enterprise-utils": {
-      "version": "9.1.0",
-      "license": "AGPL-3.0",
-      "dependencies": {
-        "@testing-library/react": "12.1.4",
-        "history": "4.10.1"
-      },
-      "peerDependencies": {
-        "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
-        "react": "^16.12.0 || ^17.0.0",
-        "react-dom": "^16.12.0 || ^17.0.0",
-        "react-router-dom": "^6.0.0"
-      }
-    },
     "node_modules/@edx/frontend-platform": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-8.3.2.tgz",
       "integrity": "sha512-LLAJ4ZKOL1LCBam6a0VWER36sibpRZFr0GJBVeF2rWbnCTdIALl+i7L0u/Th+O/i0Qt3WtAvjZQiieulNYNX0Q==",
       "license": "AGPL-3.0",
+      "peer": true,
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -2640,6 +2646,7 @@
       "version": "1.2.32",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.32"
       },
@@ -3233,6 +3240,7 @@
     "node_modules/@jest/transform": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -3268,6 +3276,7 @@
     "node_modules/@jest/types": {
       "version": "29.6.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3496,6 +3505,7 @@
       "resolved": "https://registry.npmjs.org/@openedx/frontend-build/-/frontend-build-14.3.3.tgz",
       "integrity": "sha512-I1xjpNV8m0ztbTFsh3YTeqcgc+9GqOtywdFnoXKzeCvjuQF/LVTmGg59/Cv0l9VisT82bI0cpi5DM4SwgHyQRA==",
       "license": "AGPL-3.0",
+      "peer": true,
       "dependencies": {
         "@babel/cli": "7.24.8",
         "@babel/core": "7.24.9",
@@ -3578,6 +3588,7 @@
       "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.4.2.tgz",
       "integrity": "sha512-ChI/jFJb1u9HMwfNFkKqmC+S48IWBl2JiRP9nYmXzs04y+2nPYzPYeXSq+ss1hTET+A+QycpIbrtkr9Tmn7u/A==",
       "license": "Apache-2.0",
+      "peer": true,
       "workspaces": [
         "example",
         "component-generator",
@@ -4130,6 +4141,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4185,6 +4197,7 @@
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4377,6 +4390,7 @@
     "node_modules/@svgr/core": {
       "version": "8.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4471,6 +4485,7 @@
       "version": "9.3.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4521,6 +4536,7 @@
     "node_modules/@testing-library/react": {
       "version": "12.1.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0",
@@ -5091,6 +5107,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -5137,6 +5154,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5595,6 +5613,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5658,6 +5677,7 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6104,6 +6124,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
       "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6160,6 +6181,7 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -6205,6 +6227,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6600,6 +6623,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -8227,6 +8251,7 @@
       "version": "3.11.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array.prototype.flat": "^1.2.3",
         "cheerio": "^1.0.0-rc.3",
@@ -8529,6 +8554,7 @@
     "node_modules/eslint": {
       "version": "8.44.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -8585,6 +8611,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
       "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0",
         "object.assign": "^4.1.2",
@@ -8625,6 +8652,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.1.0.tgz",
       "integrity": "sha512-GPxI5URre6dDpJ0CtcthSZVBAfI+Uw7un5OYNVxP2EYi3H81Jw701yFP7AU+/vCE7xBtFmjge7kfhhk4+RAiig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0"
       },
@@ -8851,6 +8879,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -8905,6 +8934,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
       "integrity": "sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.7",
         "aria-query": "^5.1.3",
@@ -8941,6 +8971,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
       "integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flatmap": "^1.3.1",
@@ -8971,6 +9002,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.1.tgz",
       "integrity": "sha512-Ck77j8hF7l9N4S/rzSLOWEKpn994YH6iwUK8fr9mXIaQvGpQYmOnQLbiue1u5kI5T1y+gdgqosnEAO9NCz0DBg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9449,6 +9481,7 @@
     "node_modules/file-loader": {
       "version": "6.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
@@ -10621,6 +10654,7 @@
     "node_modules/image-minimizer-webpack-plugin/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11647,6 +11681,7 @@
     "node_modules/jest": {
       "version": "29.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -14119,6 +14154,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -14856,6 +14892,7 @@
     "node_modules/prop-types": {
       "version": "15.7.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -15127,6 +15164,7 @@
     "node_modules/react": {
       "version": "17.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -15227,6 +15265,7 @@
     "node_modules/react-dom": {
       "version": "17.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -15502,6 +15541,7 @@
     "node_modules/react-redux": {
       "version": "7.2.9",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -15527,6 +15567,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.16.0.tgz",
       "integrity": "sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15606,6 +15647,7 @@
     "node_modules/react-router-dom": {
       "version": "6.15.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.8.0",
         "react-router": "6.15.0"
@@ -15673,6 +15715,7 @@
       "version": "17.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "react-is": "^17.0.2",
@@ -15790,6 +15833,7 @@
     "node_modules/redux": {
       "version": "4.0.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
@@ -17288,6 +17332,7 @@
       "integrity": "sha512-93ISASYmvGdKOvNHFaOZ+mVsCNQdoZzhSEq7JINE0BjMoE8zUzkwFyGDUBnfmXayHq/F4B4MCWmtjqjgHAYthw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
         "@bundled-es-modules/glob": "^10.4.2",
@@ -17591,6 +17636,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17853,6 +17899,7 @@
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.4.tgz",
       "integrity": "sha512-YiHwDhSvCiItoAgsKtoLFCuakDzDsJ1DLDnSouTaTmdOcOwIkSzbLXduaQ6M5DRVhuZC/NYaaZ/mtHbWMv/S6Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
@@ -17940,7 +17987,8 @@
     },
     "node_modules/tslib": {
       "version": "2.6.3",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -17993,6 +18041,7 @@
     "node_modules/type-fest": {
       "version": "0.21.3",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18090,6 +18139,7 @@
     "node_modules/typescript": {
       "version": "4.9.5",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18488,6 +18538,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -18582,6 +18633,7 @@
     "node_modules/webpack-cli": {
       "version": "5.1.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -18657,6 +18709,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18710,6 +18763,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -18769,6 +18823,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18893,6 +18948,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-    "@edx/frontend-enterprise-utils": "9.1.0",
+    "@2uinc/frontend-enterprise-utils": "^10.0.2",
     "@edx/frontend-platform": "^8.3.2",
     "@edx/openedx-atlas": "^0.6.0",
     "@fortawesome/fontawesome-svg-core": "1.2.32",

--- a/src/Configuration/Provisioning/DashboardDataTable/tests/DashboardDataTable.test.jsx
+++ b/src/Configuration/Provisioning/DashboardDataTable/tests/DashboardDataTable.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { camelCaseObject } from '@edx/frontend-platform';

--- a/src/Configuration/Provisioning/DashboardDataTable/tests/DashboardTableBadges.test.jsx
+++ b/src/Configuration/Provisioning/DashboardDataTable/tests/DashboardTableBadges.test.jsx
@@ -1,4 +1,4 @@
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { screen } from '@testing-library/react';
 import DashboardTableBadges from '../DashboardTableBadges';
 

--- a/src/Configuration/Provisioning/ErrorPage/tests/ErrorPageButton.test.jsx
+++ b/src/Configuration/Provisioning/ErrorPage/tests/ErrorPageButton.test.jsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen } from '@testing-library/react';
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { Link } from 'react-router-dom';
 import ErrorPageButton from '../ErrorPageButton';
 

--- a/src/Configuration/Provisioning/ErrorPage/tests/ErrorPageContainer.test.jsx
+++ b/src/Configuration/Provisioning/ErrorPage/tests/ErrorPageContainer.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen, cleanup } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import ErrorPageContainer from '../ErrorPageContainer';

--- a/src/Configuration/Provisioning/ErrorPage/tests/ErrorPageImage.test.jsx
+++ b/src/Configuration/Provisioning/ErrorPage/tests/ErrorPageImage.test.jsx
@@ -1,4 +1,4 @@
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { screen } from '@testing-library/react';
 import ErrorPageImage from '../ErrorPageImage';
 import ErrorPage from '../data/images/ErrorPage.svg';

--- a/src/Configuration/Provisioning/ErrorPage/tests/ErrorPageMessage.test.jsx
+++ b/src/Configuration/Provisioning/ErrorPage/tests/ErrorPageMessage.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { screen } from '@testing-library/react';
 import ErrorPageMessage from '../ErrorPageMessage';
 import { ERROR_PAGE_TEXT } from '../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/CustomCatalog/tests/ProvisioningFormCustomCatalog.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/CustomCatalog/tests/ProvisioningFormCustomCatalog.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { screen, act } from '@testing-library/react';
 import ProvisioningFormCustomCatalog from '../ProvisioningFormCustomCatalog';
 import { singlePolicy } from '../../../../testData';

--- a/src/Configuration/Provisioning/ProvisioningForm/CustomCatalog/tests/ProvisioningFormCustomCatalogDropdown.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/CustomCatalog/tests/ProvisioningFormCustomCatalogDropdown.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import {
   fireEvent, screen, waitFor, act,
 } from '@testing-library/react';

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormAccountDetails.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormAccountDetails.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { initialStateValue, ProvisioningContext } from '../../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT, { INITIAL_POLICIES, PREDEFINED_QUERIES_ENUM } from '../../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormCatalog.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormCatalog.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import ProvisioningFormCatalog from '../ProvisioningFormCatalog';
 import { initialStateValue, ProvisioningContext } from '../../../../testData/Provisioning';

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormCatalogContainer.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormCatalogContainer.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import { screen } from '@testing-library/react';
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { initialStateValue, ProvisioningContext } from '../../../../testData/Provisioning';
 import ProvisioningFormCatalogContainer from '../ProvisioningFormCatalogContainer';
 import PROVISIONING_PAGE_TEXT from '../../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormDescription.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormDescription.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { screen, fireEvent } from '@testing-library/react';
 import { ProvisioningContext, initialStateValue } from '../../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT from '../../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPerLearnerCap.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPerLearnerCap.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { initialStateValue, ProvisioningContext } from '../../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT, { INITIAL_POLICIES } from '../../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPerLearnerCapAmount.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPerLearnerCapAmount.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { initialStateValue, ProvisioningContext } from '../../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT, { INITIAL_POLICIES } from '../../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPerLearnerCapContainer.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPerLearnerCapContainer.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { initialStateValue, ProvisioningContext } from '../../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT, { INITIAL_POLICIES } from '../../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPolicyContainer.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPolicyContainer.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPolicyType.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPolicyType.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { ProvisioningContext, initialStateValue } from '../../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT, { INITIAL_POLICIES } from '../../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningForm.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningForm.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { screen, waitFor } from '@testing-library/react';
 import { ProvisioningContext, initialStateValue } from '../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormAccountType.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormAccountType.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormCustomer.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormCustomer.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { ProvisioningContext, initialStateValue } from '../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormCustomerDropdown.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormCustomerDropdown.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen, act } from '@testing-library/react';
 import { ProvisioningContext, initialStateValue } from '../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormInternalOnly.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormInternalOnly.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { ProvisioningContext, initialStateValue } from '../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormSubmissionButton.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormSubmissionButton.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import ProvisioningFormSubmissionButton from '../ProvisioningFormSubmissionButton';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormSubsidy.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormSubsidy.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import ProvisioningFormSubsidy from '../ProvisioningFormSubsidy';
 import { ProvisioningContext, initialStateValue } from '../../../testData/Provisioning';

--- a/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormTerm.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormTerm.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { ProvisioningContext, initialStateValue } from '../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';

--- a/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormTitle.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/tests/ProvisioningFormTitle.test.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import { ProvisioningContext, initialStateValue } from '../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';

--- a/src/Configuration/Provisioning/SubsidyDetailView/PolicyDetailView/tests/CustomCatalogDetail.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyDetailView/PolicyDetailView/tests/CustomCatalogDetail.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 

--- a/src/Configuration/Provisioning/SubsidyDetailView/tests/EditButton.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyDetailView/tests/EditButton.test.jsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/extend-expect';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import EditButton from '../EditButton';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';
 

--- a/src/Configuration/Provisioning/SubsidyDetailView/tests/SubsidyDetailView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyDetailView/tests/SubsidyDetailView.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import '@testing-library/jest-dom/extend-expect';
 import SubsidyDetailView from '../SubsidyDetailView';
 import { initialStateValue, ProvisioningContext } from '../../../testData/Provisioning';

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/CancelButton.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/CancelButton.test.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { screen, waitFor } from '@testing-library/react';
 import Router from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import CancelButton from '../CancelButton';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';
 import { hydratedInitialState, ProvisioningContext } from '../../../testData/Provisioning/ProvisioningContextWrapper';

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/SaveEditsButton.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/SaveEditsButton.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import SaveEditsButton from '../SaveEditsButton';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';
 import { hydratedInitialState, ProvisioningContext } from '../../../testData/Provisioning/ProvisioningContextWrapper';

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import '@testing-library/jest-dom/extend-expect';
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { initialStateValue, ProvisioningContext } from '../../../testData/Provisioning/ProvisioningContextWrapper';

--- a/src/Configuration/Provisioning/test/Dashboard.test.jsx
+++ b/src/Configuration/Provisioning/test/Dashboard.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { useLocation } from 'react-router-dom';
 import Dashboard from '../Dashboard';
 import PROVISIONING_PAGE_TEXT, { toastText } from '../data/constants';

--- a/src/Configuration/Provisioning/test/ProvisioningPage.test.jsx
+++ b/src/Configuration/Provisioning/test/ProvisioningPage.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import { fireEvent, screen } from '@testing-library/react';
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { renderWithRouter } from '@2uinc/frontend-enterprise-utils';
 import { camelCaseObject } from '@edx/frontend-platform';
 import ROUTES from '../../../data/constants/routes';
 import PROVISIONING_PAGE_TEXT from '../data/constants';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Routes, Route } from 'react-router-dom';
 
-import { hasFeatureFlagEnabled } from '@edx/frontend-enterprise-utils';
+import { hasFeatureFlagEnabled } from '@2uinc/frontend-enterprise-utils';
 import { v4 as uuidv4 } from 'uuid';
 import Header from './supportHeader';
 import messages from './i18n';


### PR DESCRIPTION
Replace the abandoned @edx/frontend-enterprise-utils dependency with @2uinc/frontend-enterprise-utils. Expand Jest transformIgnorePatterns to cover the @2uinc scope since @openedx/frontend-build only handles @edx and @openedx by default.