### PR TITLE
fix: enterprise customer detail modal display bug

### DIFF
--- a/src/Configuration/Customers/CustomerDetailView/CustomerDetailModal.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerDetailModal.jsx
@@ -19,6 +19,7 @@ const CustomerDetailModal = ({ customer, isOpen, close }) => {
       size="lg"
       hasCloseButton
       isFullscreenOnMobile
+      isOverflowVisible={false}
     >
       <ModalDialog.Header>
         <h1>


### PR DESCRIPTION
Explicitly set the `isOverflowVisible` prop to `false` on the `CustomerDetailModal`, to fix the display of the modal.

## ---------BEFORE----------

<img width="801" height="923" alt="Screenshot 2026-05-05 at 5 13 53 PM" src="https://github.com/user-attachments/assets/7dbac002-2cd8-4c1a-ace4-d69b93fd45eb" />


## ---------AFTER---------

<img width="800" height="750" alt="Screenshot 2026-05-05 at 5 13 30 PM" src="https://github.com/user-attachments/assets/0bee7401-4c2e-4495-a9ab-48b5152e76ec" />